### PR TITLE
Update to use new atomic-host path

### DIFF
--- a/roles/foreman/templates/template_FedoraAtomicKickstart
+++ b/roles/foreman/templates/template_FedoraAtomicKickstart
@@ -60,7 +60,7 @@ EOF
 bootloader --timeout=3 --append="ds=nocloud\;seedfrom=/var/cloud-init/"
 text
 
-ostreesetup --nogpg --osname="fedora-atomic" --remote="fedora-atomic-{{ fedora_version }}" --url="http://{{ foreman_hostname}}.{{ foreman_subdomain }}/atomic" --ref="fedora/{{ fedora_version }}/x86_64/atomic-host"
+ostreesetup --nogpg --osname="fedora-atomic" --remote="fedora-atomic-{{ fedora_version }}" --url="http://{{ foreman_hostname}}.{{ foreman_subdomain }}/atomic" --ref="fedora/{{ fedora_version }}/x86_64/testing/atomic-host"
 
 services --enabled cloud-init,cloud-config,cloud-final,cloud-init-local,sshd,docker
 rootpw --iscrypted <%= root_pass %>


### PR DESCRIPTION
https://pagure.io/fedora-atomic/c/cfe724f9cc1adbc07b097bb80f28fa1677ca5a91?branch=f26

^ That commit broke us. I'm not entirely sure what the impetus for that change was, or if it really should be behind that testing dir. Could probably reach out to the atomic guys.