### PR TITLE
Source metallb from bitnami chart

### DIFF
--- a/roles/k8s_nginx_ingress/tasks/main.yml
+++ b/roles/k8s_nginx_ingress/tasks/main.yml
@@ -4,10 +4,10 @@
     msg: "metallb_ip_range must be set, not '{{ metallb_ip_range }}'"
   when: not metallb_ip_range
 
-- name: Add stable chart repo
+- name: Add bitnami chart repo
   community.kubernetes.helm_repository:
-    name: stable
-    repo_url: "https://kubernetes-charts.storage.googleapis.com"
+    name: bitnami
+    repo_url: https://charts.bitnami.com/bitnami
 
 - name: Add ingress_nginx helm repo
   community.kubernetes.helm_repository:
@@ -28,7 +28,7 @@
     community.kubernetes.helm:
       name: metallb
       namespace: metallb-system
-      chart_ref: stable/metallb
+      chart_ref: bitnami/metallb
       values:
         configInline:
           address-pools:


### PR DESCRIPTION
Had some errors trying to install the stable chart claiming that metallb was not found and required an "update"? Think the stable is also deprecated, which pointed me to bitnami as the maintained chart.